### PR TITLE
feat: support foreign elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,28 @@ assertEquals(content, serialized);
 HtmlCrunch implements the following parts of the
 [HTML spec](https://html.spec.whatwg.org/):
 
-| spec                                                                    | status           |
-| ----------------------------------------------------------------------- | ---------------- |
-| [end tag omission](https://html.spec.whatwg.org/#syntax-tag-omission)   | ✅               |
-| [start tag omission](https://html.spec.whatwg.org/#syntax-tag-omission) | 🚫 (not planned) |
-| x                                                                       | y                |
+| spec                                                                                           | status             |
+| ---------------------------------------------------------------------------------------------- | ------------------ |
+| [document structure](https://html.spec.whatwg.org/#writing)                                    | ✅                 |
+| [modern doctype](https://html.spec.whatwg.org/#the-doctype)                                    | ✅                 |
+| [legacy doctype](https://html.spec.whatwg.org/#doctype-legacy-string)                          | 🚫 (not planned)   |
+| **[Elements](https://html.spec.whatwg.org/#elements-2)**                                       |                    |
+| self-closing void elements                                                                     | ✅                 |
+| raw text elements                                                                              | ✅                 |
+| foreign elements (MathML & SVG namespaces)                                                     | ✅                 |
+| normal elements                                                                                | ✅                 |
+| **[Attributes](https://html.spec.whatwg.org/#attributes-2)**                                   |                    |
+| Empty attribute syntax                                                                         | ✅                 |
+| Unquoted attribute value syntax                                                                | ✅                 |
+| Single-quoted attribute value syntax                                                           | ✅                 |
+| Double-quoted attribute value syntax                                                           | ✅                 |
+| **[Optional tags]((https://html.spec.whatwg.org/#syntax-tag-omission))**                       |                    |
+| end tag omission                                                                               | ✅                 |
+| start tag omission                                                                             | 🚫 (not planned)   |
+| content model validation and [restriction](https://html.spec.whatwg.org/#element-restrictions) | ⚠️ (not supported) |
+| [text](https://html.spec.whatwg.org/#text-2)                                                   | ✅                 |
+| [CDATA sections](https://html.spec.whatwg.org/#cdata-sections)                                 | ⚠️ (not supported) |
+| [comments](https://html.spec.whatwg.org/#comments)                                             | ✅                 |
 
 ## End tag omission
 
@@ -123,8 +140,8 @@ const table = element.parseOrThrow(
 
 ## API
 
-See the [interactive documentation](https://jsr.io/@fcrozatier/htmlcrunch/doc)
-on JSR.
+The [interactive documentation](https://jsr.io/@fcrozatier/htmlcrunch/doc) is
+available on JSR.
 
 The [elements](https://jsr.io/@fcrozatier/htmlcrunch/doc/~/element),
 [fragments](https://jsr.io/@fcrozatier/htmlcrunch/doc/~/fragments),

--- a/parser.ts
+++ b/parser.ts
@@ -334,7 +334,7 @@ const startTag: Parser<MElement> = seq(
  *
  * ```ts
  * import { commentNode } from "@fcrozatier/htmlcrunch";
- * import { assertEquals } from "@std/assert";
+ * import { assertObjectMatch } from "@std/assert";
  *
  * const hangingBracket = element.parseOrThrow(
  *   `<input
@@ -342,7 +342,7 @@ const startTag: Parser<MElement> = seq(
  *   >`,
  * );
  *
- * assertEquals(hangingBracket, {
+ * assertObjectMatch(hangingBracket, {
  *   tagName: "input",
  *   kind: "VOID",
  *   attributes: [["disabled",""]],
@@ -493,13 +493,13 @@ export const element: Parser<MElement> = createParser((input, position) => {
  *
  * ```ts
  * import { fragments, Kind } from "@fcrozatier/htmlcrunch";
- * import { assertEquals } from "@std/assert";
+ * import { assertObjectMatch } from "@std/assert";
  *
  * const content = fragments.parseOrThrow(
  *   '<img src="image.png"><br><input type=submit value=Ok />',
  * )
  *
- * assertEquals(content, [
+ * assertObjectMatch({ content }, { content: [
  *   {
  *     tagName: "img",
  *     kind: Kind.VOID,
@@ -511,7 +511,7 @@ export const element: Parser<MElement> = createParser((input, position) => {
  *     kind: Kind.VOID,
  *     attributes: [["type", "submit"], ["value", "Ok"]],
  *   },
- * ]);
+ * ]});
  * ```
  *
  * @see {@linkcode element}

--- a/tests/document_structure.test.ts
+++ b/tests/document_structure.test.ts
@@ -1,0 +1,61 @@
+import { assertEquals } from "@std/assert";
+import { doctype, html, serializeFragments, textNode } from "../parser.ts";
+
+Deno.test("doctype", () => {
+  const res = doctype.parseOrThrow("<!Doctype Html >");
+
+  assertEquals(res, textNode("<!DOCTYPE html>"));
+});
+
+Deno.test("html document structure", () => {
+  const content = html.parseOrThrow(
+    `\ufeff
+
+<!-- Before doctype -->
+
+<!DOCTYPE html>
+
+<!-- Before html -->
+
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Document</title>
+</head>
+<body>
+    The body
+</body>
+</html>
+
+<!-- After html -->
+
+`,
+  );
+
+  assertEquals(
+    serializeFragments(content),
+    `\ufeff
+
+<!-- Before doctype -->
+
+<!DOCTYPE html>
+
+<!-- Before html -->
+
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Document</title>
+</head>
+<body>
+    The body
+</body>
+</html>
+
+<!-- After html -->
+
+`,
+  );
+});

--- a/tests/elements.test.ts
+++ b/tests/elements.test.ts
@@ -1,0 +1,227 @@
+import { ParseError } from "@fcrozatier/monarch";
+import { assertEquals } from "@std/assert/equals";
+import { assertInstanceOf } from "@std/assert/instance-of";
+import { assertObjectMatch } from "@std/assert/object-match";
+import { assertStringIncludes } from "@std/assert/string-includes";
+import { unreachable } from "@std/assert/unreachable";
+import {
+  customElementName,
+  element,
+  ElementKind,
+  serializeNode,
+  textNode,
+} from "../parser.ts";
+
+Deno.test("raw text elements", () => {
+  const style = element.parseOrThrow(
+    `<style>
+      .box {
+        color: blue;
+      }
+    </style>`,
+  );
+
+  assertObjectMatch(style, {
+    tagName: "style",
+    kind: ElementKind.RAW_TEXT,
+    attributes: [],
+    children: [{
+      kind: "TEXT",
+      text: `
+      .box {
+        color: blue;
+      }
+    `,
+    }],
+  });
+
+  const script = element.parseOrThrow(
+    `<script>
+      <
+      </
+      </s
+      </sc
+      </scr
+      </scri
+      </scrip
+      console.log(1 < 2);
+    </script>`,
+  );
+
+  assertObjectMatch(script, {
+    tagName: "script",
+    kind: ElementKind.RAW_TEXT,
+    attributes: [],
+    children: [{
+      kind: "TEXT",
+      text: `
+      <
+      </
+      </s
+      </sc
+      </scr
+      </scri
+      </scrip
+      console.log(1 < 2);
+    `,
+    }],
+  });
+});
+
+Deno.test("empty raw text element", () => {
+  const script = element.parseOrThrow(
+    `<script type="module" src="/src/module.js"></script>`,
+  );
+
+  assertEquals(script, {
+    tagName: "script",
+    kind: ElementKind.RAW_TEXT,
+    attributes: [["type", "module"], ["src", "/src/module.js"]],
+    children: [],
+  });
+});
+
+Deno.test("normal element", () => {
+  const empty_span = element.parseOrThrow(
+    `<span class="icon"></span>`,
+  );
+  assertObjectMatch(empty_span, {
+    tagName: "span",
+    kind: ElementKind.NORMAL,
+    attributes: [["class", "icon"]],
+    children: [],
+  });
+
+  const p = element.parseOrThrow(
+    `<p>lorem</p>`,
+  );
+  assertObjectMatch(p, {
+    tagName: "p",
+    kind: ElementKind.NORMAL,
+    attributes: [],
+    children: [{ kind: "TEXT", text: "lorem" }],
+  });
+});
+
+Deno.test("custom element names", () => {
+  try {
+    // Must include a dash
+    customElementName.parseOrThrow("abc");
+    unreachable();
+  } catch (error) {
+    assertInstanceOf(error, ParseError);
+    assertStringIncludes(error?.message, "Invalid custom element name");
+  }
+
+  try {
+    // Cannot be a forbidden name
+    customElementName.parseOrThrow("annotation-xml");
+    unreachable();
+  } catch (error) {
+    assertInstanceOf(error, ParseError);
+    assertStringIncludes(error?.message, "Forbidden custom element name");
+  }
+});
+
+Deno.test("custom elements", () => {
+  const res = element.parseOrThrow(
+    `<something-different>
+      <atom-text-editor mini>
+        Hello
+      </atom-text-editor>
+    </something-different>`,
+  );
+
+  const node = {
+    tagName: "something-different",
+    kind: ElementKind.NORMAL,
+    attributes: [],
+    children: [textNode("\n      "), {
+      tagName: "atom-text-editor",
+      kind: ElementKind.NORMAL,
+      attributes: [["mini", ""]],
+      children: [textNode("\n        Hello\n      ")],
+    }, textNode("\n    ")],
+  };
+
+  assertObjectMatch(res, node);
+});
+
+Deno.test("foreign svg elements", () => {
+  const markup =
+    `<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+<!-- A self-closing tag -->
+<circle cx="50" cy="50" r="40" stroke="green" fill="yellow"/>
+
+<!-- Another self-closing tag but without the slash (valid in HTML, not in XML) -->
+<rect x="10" y="10" width="30" height="30">
+
+  <!-- Embedded foreign content  -->
+  <script type="application/ecmascript">
+      console.log("Inside SVG &lt;script&gt;");
+  </script>
+
+  <!-- Nested elements with same tag name -->
+  <g>
+    <g>
+      <text x="10" y="90">Nested <tspan font-weight="bold">text</tspan> inside</text>
+    </g>
+  </g>
+
+  <!-- Namespaced element -->
+  <animateTransform attributeName="transform" type="rotate" from="0 50 50" to="360 50 50" dur="10s" repeatCount="indefinite"/>
+</rect>
+</svg>`;
+
+  const svg = element.parseOrThrow(markup);
+
+  assertEquals(serializeNode(svg), markup.replaceAll("/>", ">"));
+});
+
+Deno.test("foreign math elements", () => {
+  const markup =
+    `<math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+  <!-- Fractions -->
+  <mfrac>
+    <mrow>
+      <mi>a</mi>
+      <mo>+</mo>
+      <mi>b</mi>
+    </mrow>
+    <mrow>
+      <mi>c</mi>
+      <mo>+</mo>
+      <mi>d</mi>
+    </mrow>
+  </mfrac>
+
+  <!-- Superscript and invisible multiplication -->
+  <mo>&InvisibleTimes;</mo>
+  <msup>
+    <mi>x</mi>
+    <mn>2</mn>
+  </msup>
+
+  <mo>/</mo>
+  <msqrt>
+    <mrow>
+      <mi>e</mi>
+      <mo>−</mo>
+      <mi>f</mi>
+    </mrow>
+  </msqrt>
+
+  <!-- Inline text -->
+  <mtext fontstyle="italic">result ≠ expected</mtext>
+
+  <semantics>
+    <mrow>
+      <mi>π</mi>
+    </mrow>
+    <annotation encoding="application/x-tex">pi</annotation>
+  </semantics>
+</math>`;
+
+  const math = element.parseOrThrow(markup);
+  assertEquals(serializeNode(math), markup);
+});

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -2,19 +2,13 @@ import { ParseError } from "@fcrozatier/monarch";
 import {
   assert,
   assertEquals,
-  assertExists,
   assertInstanceOf,
   assertObjectMatch,
-  assertStringIncludes,
   unreachable,
 } from "@std/assert";
 import {
-  customElementName,
-  doctype,
-  element,
   ElementKind,
   fragments,
-  html,
   isCommentNode,
   isElementNode,
   isMNode,
@@ -23,148 +17,6 @@ import {
   shadowRoot,
   textNode,
 } from "../parser.ts";
-
-Deno.test("doctype", () => {
-  const res = doctype.parseOrThrow("<!Doctype Html >");
-
-  assertEquals(res, textNode("<!DOCTYPE html>"));
-});
-
-Deno.test("custom element names", () => {
-  try {
-    // Must include a dash
-    customElementName.parseOrThrow("abc");
-    unreachable();
-  } catch (error) {
-    assertInstanceOf(error, ParseError);
-    assertStringIncludes(error?.message, "Invalid custom element name");
-  }
-
-  try {
-    // Cannot be a forbidden name
-    customElementName.parseOrThrow("annotation-xml");
-    unreachable();
-  } catch (error) {
-    assertInstanceOf(error, ParseError);
-    assertStringIncludes(error?.message, "Forbidden custom element name");
-  }
-});
-
-Deno.test("raw text elements", () => {
-  const style = element.parseOrThrow(`
-    <style>
-      .box {
-        color: blue;
-      }
-    </style>
-    `.trim());
-
-  assertObjectMatch(style, {
-    tagName: "style",
-    kind: ElementKind.RAW_TEXT,
-    attributes: [],
-    children: [{
-      kind: "TEXT",
-      text: `
-      .box {
-        color: blue;
-      }
-    `,
-    }],
-  });
-
-  const script = element.parseOrThrow(`
-    <script>
-      <
-      </
-      </s
-      </sc
-      </scr
-      </scri
-      </scrip
-      console.log(1 < 2);
-    </script>
-    `.trim());
-
-  assertObjectMatch(script, {
-    tagName: "script",
-    kind: ElementKind.RAW_TEXT,
-    attributes: [],
-    children: [{
-      kind: "TEXT",
-      text: `
-      <
-      </
-      </s
-      </sc
-      </scr
-      </scri
-      </scrip
-      console.log(1 < 2);
-    `,
-    }],
-  });
-});
-
-Deno.test("empty raw text element", () => {
-  const script = element.parseOrThrow(
-    `<script type="module" src="/src/module.js"></script>`,
-  );
-
-  assertEquals(script, {
-    tagName: "script",
-    kind: ElementKind.RAW_TEXT,
-    attributes: [["type", "module"], ["src", "/src/module.js"]],
-    children: [],
-  });
-});
-
-Deno.test("normal element", () => {
-  const empty_span = element.parseOrThrow(
-    `<span class="icon"></span>`,
-  );
-  assertObjectMatch(empty_span, {
-    tagName: "span",
-    kind: ElementKind.NORMAL,
-    attributes: [["class", "icon"]],
-    children: [],
-  });
-
-  const p = element.parseOrThrow(
-    `<p>lorem</p>`,
-  );
-  assertObjectMatch(p, {
-    tagName: "p",
-    kind: ElementKind.NORMAL,
-    attributes: [],
-    children: [{ kind: "TEXT", text: "lorem" }],
-  });
-});
-
-Deno.test("custom elements", () => {
-  const res = fragments.parseOrThrow(`
-    <something-different>
-      <atom-text-editor mini>
-        Hello
-      </atom-text-editor>
-    </something-different>
-    `.trim());
-
-  const node = {
-    tagName: "something-different",
-    kind: ElementKind.NORMAL,
-    attributes: [],
-    children: [textNode("\n      "), {
-      tagName: "atom-text-editor",
-      kind: ElementKind.NORMAL,
-      attributes: [["mini", ""]],
-      children: [textNode("\n        Hello\n      ")],
-    }, textNode("\n    ")],
-  };
-
-  assertExists(res[0]);
-  assertObjectMatch(res[0], node);
-});
 
 Deno.test("entities", () => {
   const entities = fragments.parseOrThrow(`
@@ -314,22 +166,6 @@ Deno.test("declarative shadowroot", () => {
   </article>
 </template>
 `,
-  );
-});
-
-Deno.test("html", () => {
-  html.parseOrThrow(
-    `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Document</title>
-</head>
-<body>
-
-</body>
-</html>`,
   );
 });
 

--- a/tests/tags.test.ts
+++ b/tests/tags.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertObjectMatch } from "@std/assert";
 import { attribute, element, ElementKind, tagName } from "../parser.ts";
 
 Deno.test("tag names are lowercased", () => {
@@ -27,7 +27,7 @@ Deno.test("attributes", () => {
     disabled
     >`,
   );
-  assertEquals(hangingBracket, {
+  assertObjectMatch(hangingBracket, {
     tagName: "input",
     kind: ElementKind.VOID,
     attributes: [
@@ -41,7 +41,7 @@ Deno.test("attributes", () => {
   const recoverFromMissingWhiteSpace = element.parseOrThrow(
     `<input value="yes"class="a b c">`,
   );
-  assertEquals(recoverFromMissingWhiteSpace, {
+  assertObjectMatch(recoverFromMissingWhiteSpace, {
     tagName: "input",
     kind: ElementKind.VOID,
     attributes: [
@@ -53,7 +53,7 @@ Deno.test("attributes", () => {
   const allowDuplicateAttributes = element.parseOrThrow(
     `<input on:click="handleClick" on:click="log">`,
   );
-  assertEquals(allowDuplicateAttributes, {
+  assertObjectMatch(allowDuplicateAttributes, {
     tagName: "input",
     kind: ElementKind.VOID,
     attributes: [
@@ -65,7 +65,7 @@ Deno.test("attributes", () => {
   const keepAttributesCasing = element.parseOrThrow(
     `<input prop:ariaChecked="checked">`,
   );
-  assertEquals(keepAttributesCasing, {
+  assertObjectMatch(keepAttributesCasing, {
     tagName: "input",
     kind: ElementKind.VOID,
     attributes: [

--- a/tests/void_elements.test.ts
+++ b/tests/void_elements.test.ts
@@ -36,7 +36,7 @@ Deno.test("disallow self-closing non-void elements", () => {
     assertInstanceOf(error, ParseError);
     assert(
       error.message.includes(
-        "Unexpected self-closing tag on a non-void element",
+        "Unexpected self-closing tag",
       ),
     );
   }
@@ -48,7 +48,7 @@ Deno.test("disallow closing tags on void elements", () => {
     unreachable();
   } catch (error) {
     assertInstanceOf(error, ParseError);
-    assert(error.message.includes("Unexpected end tag on a void element"));
+    assert(error.message.includes("Unexpected end tag"));
   }
 
   try {
@@ -60,7 +60,7 @@ Deno.test("disallow closing tags on void elements", () => {
     unreachable();
   } catch (error) {
     assertInstanceOf(error, ParseError);
-    assert(error.message.includes("Unexpected end tag on a void element"));
+    assert(error.message.includes("Unexpected end tag"));
   }
 });
 

--- a/tests/void_elements.test.ts
+++ b/tests/void_elements.test.ts
@@ -1,15 +1,16 @@
 import { ParseError } from "@fcrozatier/monarch";
 import {
   assert,
-  assertEquals,
   assertInstanceOf,
+  assertObjectMatch,
   unreachable,
 } from "@std/assert";
 import { element, ElementKind, fragments } from "../parser.ts";
 
 Deno.test("simple void element", () => {
   const input = element.parseOrThrow('<input type="text">');
-  assertEquals(input, {
+
+  assertObjectMatch(input, {
     tagName: "input",
     kind: ElementKind.VOID,
     attributes: [["type", "text"]],
@@ -19,7 +20,8 @@ Deno.test("simple void element", () => {
 Deno.test("On void elements the closing slash is part of the unquoted attribute value", () => {
   // https://html.spec.whatwg.org/#start-tags
   const unquoted_attr_then_slash = element.parseOrThrow("<input type=text/>");
-  assertEquals(unquoted_attr_then_slash, {
+
+  assertObjectMatch(unquoted_attr_then_slash, {
     tagName: "input",
     kind: ElementKind.VOID,
     attributes: [["type", "text/"]],
@@ -67,17 +69,19 @@ Deno.test("multiple void elements", () => {
     '<img src="something.png"><br><input type=submit value=Ok />',
   );
 
-  assertEquals(content, [
-    {
-      tagName: "img",
-      kind: ElementKind.VOID,
-      attributes: [["src", "something.png"]],
-    },
-    { tagName: "br", kind: ElementKind.VOID, attributes: [] },
-    {
-      tagName: "input",
-      kind: ElementKind.VOID,
-      attributes: [["type", "submit"], ["value", "Ok"]],
-    },
-  ]);
+  assertObjectMatch({ content }, {
+    content: [
+      {
+        tagName: "img",
+        kind: ElementKind.VOID,
+        attributes: [["src", "something.png"]],
+      },
+      { tagName: "br", kind: ElementKind.VOID, attributes: [] },
+      {
+        tagName: "input",
+        kind: ElementKind.VOID,
+        attributes: [["type", "submit"], ["value", "Ok"]],
+      },
+    ],
+  });
 });


### PR DESCRIPTION
`svg` and `math` elements have different parsing rules: self-closing elements, case-sensitive tage names etc

```ts
const markup =
    `<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
<!-- A self-closing tag -->
<circle cx="50" cy="50" r="40" stroke="green" fill="yellow"/>

<!-- Another self-closing tag but without the slash (valid in HTML, not in XML) -->
<rect x="10" y="10" width="30" height="30">

  <!-- Embedded foreign content  -->
  <script type="application/ecmascript">
      console.log("Inside SVG &lt;script&gt;");
  </script>

  <!-- Nested elements with same tag name -->
  <g>
    <g>
      <text x="10" y="90">Nested <tspan font-weight="bold">text</tspan> inside</text>
    </g>
  </g>

  <!-- Namespaced element -->
  <animateTransform attributeName="transform" type="rotate" from="0 50 50" to="360 50 50" dur="10s" repeatCount="indefinite"/>
</rect>
</svg>`;

const svg = element.parseOrThrow(markup);

assertEquals(serializeNode(svg), markup.replaceAll("/>", ">"));
```